### PR TITLE
Fix GitHub Pages base path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The generated production bundle lives in `dist/`.
 
 ## Deploying to GitHub Pages
 
-The project is already configured for GitHub Pages. Update the `base` property inside `vite.config.ts` if you publish it to a repository that uses a different name, then run:
+The project is already configured for GitHub Pages. The build now emits relative asset paths, so it will work whether you publish to `username.github.io` or to a project site such as `username.github.io/repo-name`. Deploy by running:
 
 ```bash
 npm run build

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   plugins: [react()],
-  base: "/mba-project/"
-});
+  base: command === "build" ? "./" : "/"
+}));


### PR DESCRIPTION
## Summary
- update the Vite configuration to emit relative asset paths during production builds so the bundle loads correctly on GitHub Pages
- clarify the README GitHub Pages instructions now that no manual base-path edits are required

## Testing
- not run (npm install fails with 403 in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e5f46eeaf48332814827ec779523d3