### PR TITLE
Fix GitHub Pages deployment base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The generated production bundle lives in `dist/`.
 
 ## Deploying to GitHub Pages
 
-The project is already configured for GitHub Pages. The build now emits relative asset paths, so it will work whether you publish to `username.github.io` or to a project site such as `username.github.io/repo-name`. Deploy by running:
+The build is configured to publish to the `/mba-project/` subdirectory that GitHub Pages uses for the project site. Deploy by running:
 
 ```bash
 npm run build

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,9 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
+const REPO_BASE = "/mba-project/";
+
 export default defineConfig(({ command }) => ({
   plugins: [react()],
-  base: command === "build" ? "./" : "/"
+  base: command === "serve" ? "/" : REPO_BASE
 }));


### PR DESCRIPTION
## Summary
- set the Vite base path to `/mba-project/` during builds so assets resolve correctly on GitHub Pages
- update the README to document the configured project-site subdirectory

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5f68b826c8332bc9de82c7b5266d1