### PR TITLE
Fix entry script loading on GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,8 @@
   </head>
   <body class="bg-slate-100">
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module">
+      import(`${import.meta.env.BASE_URL}src/main.tsx`);
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- load the Vite entry script through import.meta.env.BASE_URL so the correct path is used in production

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5f7d62d8c8332b5f39cf69028699d