### PR TITLE
Fix Vite entry script for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,6 @@
   </head>
   <body class="bg-slate-100">
     <div id="root"></div>
-    <script type="module">
-      import(`${import.meta.env.BASE_URL}src/main.tsx`);
-    </script>
+    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- load the Vite entrypoint using a module script tag so GitHub Pages no longer hits an undefined BASE_URL

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5f96741a08332a6798a6181f8fda0