### PR TITLE
Align GitHub Pages build configuration

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Best MBA Project Ever</title>
-    <script type="module" crossorigin src="/mba-project/assets/index-B-Nstkhw.js"></script>
-    <link rel="stylesheet" crossorigin href="/mba-project/assets/index-DcEdCNOC.css">
+    <script type="module" crossorigin src="./assets/index-B-Nstkhw.js"></script>
+    <link rel="stylesheet" crossorigin href="./assets/index-DcEdCNOC.css">
   </head>
   <body class="bg-slate-100">
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -6,9 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "build:pages": "vite build --outDir docs",
     "preview": "vite preview",
-    "deploy": "gh-pages -d dist"
+    "deploy": "gh-pages -d docs"
   },
   "dependencies": {
     "framer-motion": "^10.18.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,9 +2,10 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
-const REPO_BASE = "/mba-project/";
-
-export default defineConfig(({ command }) => ({
+export default defineConfig({
   plugins: [react()],
-  base: command === "serve" ? "/" : REPO_BASE
-}));
+  base: "./",
+  build: {
+    outDir: "docs"
+  }
+});


### PR DESCRIPTION
## Summary
- configure Vite to emit the production build into the docs directory with a relative base path like the reference project
- update npm scripts to deploy the docs output and regenerate the GitHub Pages artifacts
- remove the obsolete Jekyll bypass file that is no longer used by the regenerated docs folder

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5fc3e12608332a77f7d245de11002