### PR TITLE
Make app layout responsive across screen sizes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,21 +11,23 @@ function App() {
   const [screen, setScreen] = useState<Screen>("home");
 
   return (
-    <div className="flex justify-center bg-gradient-to-br from-gray-100 to-gray-200 min-h-screen p-6">
-      <div className="w-[390px] h-[844px] bg-white rounded-[2.5rem] shadow-2xl overflow-hidden flex flex-col border border-gray-200">
+    <div className="min-h-screen bg-gradient-to-br from-gray-100 to-gray-200 p-0 sm:p-6">
+      <div className="mx-auto flex min-h-full w-full flex-col bg-white sm:max-w-5xl sm:rounded-[2.5rem] sm:border sm:border-gray-200 sm:shadow-2xl">
         <Header />
-        {screen === "home" && <HomeScreen onNavigate={setScreen} />}
-        {screen === "jobs" && <JobsScreen onBack={() => setScreen("home")} />}
-        {screen === "professionals" && (
-          <ProfessionalsScreen onBack={() => setScreen("home")} />
-        )}
-        {screen === "aiCv" && <AiCvScreen onBack={() => setScreen("home")} onContinue={() => setScreen("cvPreview")} />}
-        {screen === "cvPreview" && (
-          <CvPreviewScreen
-            onBackToRecording={() => setScreen("aiCv")}
-            onBackToHome={() => setScreen("home")}
-          />
-        )}
+        <main className="flex-1">
+          {screen === "home" && <HomeScreen onNavigate={setScreen} />}
+          {screen === "jobs" && <JobsScreen onBack={() => setScreen("home")} />}
+          {screen === "professionals" && (
+            <ProfessionalsScreen onBack={() => setScreen("home")} />
+          )}
+          {screen === "aiCv" && <AiCvScreen onBack={() => setScreen("home")} onContinue={() => setScreen("cvPreview")} />}
+          {screen === "cvPreview" && (
+            <CvPreviewScreen
+              onBackToRecording={() => setScreen("aiCv")}
+              onBackToHome={() => setScreen("home")}
+            />
+          )}
+        </main>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- replace the fixed-size simulated mobile frame with a responsive container that scales to the viewport
- wrap the main screen content in a flexible `<main>` region so all screens expand naturally

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6016c5f248332aad865a3cb091f44