### PR TITLE
Add tab navigation to jobs screen

### DIFF
--- a/src/components/screens/JobsScreen.tsx
+++ b/src/components/screens/JobsScreen.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { ArrowLeft } from "lucide-react";
 import { Card, CardContent } from "../ui/card";
 import { Button } from "../ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
 import { cn } from "../../utils/cn";
 
 interface JobsScreenProps {
@@ -144,8 +145,6 @@ const jobSections: JobSection[] = [
 const JobsScreen = ({ onBack }: JobsScreenProps) => {
   const [activeSectionId, setActiveSectionId] = useState(jobSections[0].id);
 
-  const activeSection = jobSections.find((section) => section.id === activeSectionId) ?? jobSections[0];
-
   return (
     <div className="flex min-h-dvh flex-col bg-gray-50">
       <div className="px-4 pb-3 pt-4">
@@ -169,16 +168,15 @@ const JobsScreen = ({ onBack }: JobsScreenProps) => {
             </CardContent>
           </Card>
 
-          <div className="rounded-full bg-white/70 p-1 shadow-inner">
-            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+          <Tabs value={activeSectionId} onValueChange={setActiveSectionId} className="space-y-4">
+            <TabsList className="grid grid-cols-1 gap-2 rounded-full bg-white/70 p-1 shadow-inner sm:grid-cols-2">
               {jobSections.map((section) => {
                 const isActive = activeSectionId === section.id;
 
                 return (
-                  <button
+                  <TabsTrigger
                     key={section.id}
-                    type="button"
-                    onClick={() => setActiveSectionId(section.id)}
+                    value={section.id}
                     className={cn(
                       "rounded-2xl px-4 py-3 text-left transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500",
                       isActive
@@ -186,49 +184,55 @@ const JobsScreen = ({ onBack }: JobsScreenProps) => {
                         : "border border-transparent bg-white/90 text-gray-600 shadow-sm hover:border-gray-200 hover:bg-gray-50"
                     )}
                   >
-                    <span className={cn("text-[10px] uppercase tracking-[0.2em]", isActive ? "text-white/70" : "text-gray-400")}>Opportunities</span>
+                    <span className={cn("text-[10px] uppercase tracking-[0.2em]", isActive ? "text-white/70" : "text-gray-400")}>
+                      Opportunities
+                    </span>
                     <p className="mt-1 text-sm font-semibold leading-tight">
                       {section.label}
                     </p>
                     <p className={cn("mt-1 text-xs leading-snug", isActive ? "text-white/80" : "text-gray-500")}>{section.summary}</p>
-                  </button>
+                  </TabsTrigger>
                 );
               })}
-            </div>
-          </div>
+            </TabsList>
 
-          <Card className={cn("overflow-hidden rounded-3xl border-0 text-white shadow-lg", "bg-gradient-to-br", activeSection.gradient)}>
-            <CardContent className="space-y-3 p-5">
-              <span className="text-[10px] uppercase tracking-[0.2em] text-white/70">Opportunity focus</span>
-              <h3 className="text-lg font-semibold leading-tight">{activeSection.label}</h3>
-              <p className="text-sm text-white/80">{activeSection.summary}</p>
-              <div className="flex flex-wrap gap-2">
-                {activeSection.insights.map((insight) => (
-                  <span key={insight} className="rounded-full bg-white/15 px-3 py-1 text-[11px] font-medium text-white">
-                    {insight}
-                  </span>
+            {jobSections.map((section) => (
+              <TabsContent key={section.id} value={section.id} className="space-y-4">
+                <Card className={cn("overflow-hidden rounded-3xl border-0 text-white shadow-lg", "bg-gradient-to-br", section.gradient)}>
+                  <CardContent className="space-y-3 p-5">
+                    <span className="text-[10px] uppercase tracking-[0.2em] text-white/70">Opportunity focus</span>
+                    <h3 className="text-lg font-semibold leading-tight">{section.label}</h3>
+                    <p className="text-sm text-white/80">{section.summary}</p>
+                    <div className="flex flex-wrap gap-2">
+                      {section.insights.map((insight) => (
+                        <span key={insight} className="rounded-full bg-white/15 px-3 py-1 text-[11px] font-medium text-white">
+                          {insight}
+                        </span>
+                      ))}
+                    </div>
+                  </CardContent>
+                </Card>
+
+                {section.jobs.map((job) => (
+                  <Card
+                    key={`${section.id}-${job.title}`}
+                    className="rounded-3xl border-0 bg-white/90 shadow-md transition hover:-translate-y-0.5 hover:shadow-lg"
+                  >
+                    <CardContent className="space-y-3 p-5">
+                      <h3 className="text-lg font-semibold text-gray-800">{job.title}</h3>
+                      <p className="text-sm text-gray-500">
+                        {job.company} • {job.location}
+                      </p>
+                      <p className="text-sm text-gray-600">{job.description}</p>
+                      <Button className={cn("w-full rounded-2xl bg-gradient-to-r py-2 text-white shadow hover:brightness-110", section.ctaGradient)}>
+                        Apply now
+                      </Button>
+                    </CardContent>
+                  </Card>
                 ))}
-              </div>
-            </CardContent>
-          </Card>
-
-          {activeSection.jobs.map((job) => (
-            <Card
-              key={`${activeSection.id}-${job.title}`}
-              className="rounded-3xl border-0 bg-white/90 shadow-md transition hover:-translate-y-0.5 hover:shadow-lg"
-            >
-              <CardContent className="space-y-3 p-5">
-                <h3 className="text-lg font-semibold text-gray-800">{job.title}</h3>
-                <p className="text-sm text-gray-500">
-                  {job.company} • {job.location}
-                </p>
-                <p className="text-sm text-gray-600">{job.description}</p>
-                <Button className={cn("w-full rounded-2xl bg-gradient-to-r py-2 text-white shadow hover:brightness-110", activeSection.ctaGradient)}>
-                  Apply now
-                </Button>
-              </CardContent>
-            </Card>
-          ))}
+              </TabsContent>
+            ))}
+          </Tabs>
         </div>
 
         <div className="mt-8">

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,140 @@
+import * as React from "react";
+
+import { cn } from "../../utils/cn";
+
+type TabsContextValue = {
+  value: string;
+  setValue: (value: string) => void;
+  baseId: string;
+};
+
+const TabsContext = React.createContext<TabsContextValue | null>(null);
+
+function useTabsContext(component: string) {
+  const context = React.useContext(TabsContext);
+
+  if (!context) {
+    throw new Error(`${component} must be used within <Tabs>`);
+  }
+
+  return context;
+}
+
+export interface TabsProps extends React.HTMLAttributes<HTMLDivElement> {
+  defaultValue?: string;
+  value?: string;
+  onValueChange?: (value: string) => void;
+}
+
+export const Tabs = React.forwardRef<HTMLDivElement, TabsProps>(function Tabs(
+  { defaultValue, value: valueProp, onValueChange, className, children, ...props },
+  ref
+) {
+  const isControlled = valueProp !== undefined;
+  const internalId = React.useId();
+  const [valueState, setValueState] = React.useState(defaultValue ?? "");
+
+  const value = isControlled ? valueProp ?? "" : valueState;
+
+  const setValue = React.useCallback(
+    (nextValue: string) => {
+      if (!isControlled) {
+        setValueState(nextValue);
+      }
+
+      onValueChange?.(nextValue);
+    },
+    [isControlled, onValueChange]
+  );
+
+  const contextValue = React.useMemo(() => ({
+    value,
+    setValue,
+    baseId: internalId
+  }), [internalId, setValue, value]);
+
+  return (
+    <TabsContext.Provider value={contextValue}>
+      <div ref={ref} className={className} {...props}>
+        {children}
+      </div>
+    </TabsContext.Provider>
+  );
+});
+
+export interface TabsListProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const TabsList = React.forwardRef<HTMLDivElement, TabsListProps>(
+  function TabsList({ className, ...props }, ref) {
+    return (
+      <div
+        ref={ref}
+        role="tablist"
+        className={className}
+        {...props}
+      />
+    );
+  }
+);
+
+export interface TabsTriggerProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  value: string;
+}
+
+export const TabsTrigger = React.forwardRef<HTMLButtonElement, TabsTriggerProps>(
+  function TabsTrigger({ value, className, children, onClick, ...props }, ref) {
+    const { value: activeValue, setValue, baseId } = useTabsContext("TabsTrigger");
+    const isActive = activeValue === value;
+    const triggerId = `${baseId}-trigger-${value}`;
+    const contentId = `${baseId}-content-${value}`;
+
+    return (
+      <button
+        ref={ref}
+        id={triggerId}
+        role="tab"
+        type="button"
+        className={cn(className)}
+        aria-selected={isActive}
+        aria-controls={contentId}
+        data-state={isActive ? "active" : "inactive"}
+        onClick={(event) => {
+          onClick?.(event);
+          if (!isActive) {
+            setValue(value);
+          }
+        }}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  }
+);
+
+export interface TabsContentProps extends React.HTMLAttributes<HTMLDivElement> {
+  value: string;
+}
+
+export const TabsContent = React.forwardRef<HTMLDivElement, TabsContentProps>(
+  function TabsContent({ value, className, children, ...props }, ref) {
+    const { value: activeValue, baseId } = useTabsContext("TabsContent");
+    const isActive = activeValue === value;
+    const triggerId = `${baseId}-trigger-${value}`;
+    const contentId = `${baseId}-content-${value}`;
+
+    return (
+      <div
+        ref={ref}
+        id={contentId}
+        role="tabpanel"
+        aria-labelledby={triggerId}
+        hidden={!isActive}
+        className={cn(className)}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  }
+);


### PR DESCRIPTION
## Summary
- add a lightweight tabs primitive for shared tab interactions
- refactor the jobs screen section selector to use the tabbed experience and render per-section content through tab panels

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e62b012a0c8332b8934d4a3a54ad88