### PR TITLE
Increase base input font size to avoid iOS zoom

### DIFF
--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -7,7 +7,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(({ className, ...props },
   <input
     ref={ref}
     className={cn(
-      "flex h-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500",
+      "flex h-11 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-base shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- bump the default Input component typography to 16px to satisfy iOS Safari requirements
- slightly increase the input height to keep layout balanced after the font size change

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e63cc3411c8332acf3da510990aae5